### PR TITLE
Tournament CRUD API and filtering

### DIFF
--- a/backend/tournaments/serializers.py
+++ b/backend/tournaments/serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -8,6 +9,8 @@ from .models import Tournament, TournamentTeam
 class TournamentReadSerializer(serializers.ModelSerializer):
     registered_teams_count = serializers.SerializerMethodField()
     is_registration_open = serializers.SerializerMethodField()
+    can_register = serializers.SerializerMethodField()
+    is_creator = serializers.SerializerMethodField()
     created_by_id = serializers.IntegerField(source='created_by.id', read_only=True)
 
     class Meta:
@@ -28,13 +31,59 @@ class TournamentReadSerializer(serializers.ModelSerializer):
             'created_at',
             'registered_teams_count',
             'is_registration_open',
+            'can_register',
+            'is_creator',
         )
+
+    def _request_user(self):
+        request = self.context.get('request')
+        if not request or not request.user.is_authenticated:
+            return None
+        return request.user
 
     def get_registered_teams_count(self, obj):
         return obj.registered_teams_count
 
     def get_is_registration_open(self, obj):
         return obj.is_registration_open()
+
+    def get_can_register(self, obj):
+        return obj.can_accept_teams()
+
+    def get_is_creator(self, obj):
+        user = self._request_user()
+        if not user:
+            return False
+        return obj.created_by_id == user.id
+
+
+class TournamentWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tournament
+        fields = (
+            'title',
+            'description',
+            'registration_start',
+            'registration_end',
+            'start_date',
+            'end_date',
+            'max_teams',
+            'min_teams',
+            'rounds_count',
+        )
+
+    def validate(self, attrs):
+        instance = self.instance or Tournament()
+        for field, value in attrs.items():
+            setattr(instance, field, value)
+        try:
+            instance.clean()
+        except DjangoValidationError as exc:
+            raise ValidationError(exc.message_dict)
+        return attrs
+
+    def to_representation(self, instance):
+        return TournamentReadSerializer(instance, context=self.context).data
 
 
 class TournamentTeamRegistrationSerializer(serializers.Serializer):

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -397,3 +397,342 @@ class TournamentStatusTransitionAPITests(APITestCase):
     def test_unauthenticated_fails(self):
         resp = self.client.post(self.url, {'status': 'registration'}, format='json')
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TournamentCreateAPITests(APITestCase):
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            username='admin', email='admin@test.com', password='Pass1234!',
+            role='admin', is_staff=True, is_superuser=True,
+        )
+        self.organizer = User.objects.create_user(
+            username='organizer', email='organizer@test.com', password='Pass1234!',
+            role='organizer',
+        )
+        self.regular_user = User.objects.create_user(
+            username='regular', email='regular@test.com', password='Pass1234!',
+            role='team',
+        )
+        self.url = reverse('tournament_list_create')
+        now = timezone.now()
+        self.valid_data = {
+            'title': 'New Cup',
+            'description': 'A great tournament',
+            'registration_start': (now + timedelta(days=1)).isoformat(),
+            'registration_end': (now + timedelta(days=3)).isoformat(),
+            'start_date': (now + timedelta(days=5)).isoformat(),
+            'end_date': (now + timedelta(days=10)).isoformat(),
+            'max_teams': 16,
+            'min_teams': 4,
+            'rounds_count': 3,
+        }
+
+    def test_admin_can_create(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data['title'], 'New Cup')
+        self.assertEqual(resp.data['created_by_id'], self.admin.id)
+        self.assertEqual(resp.data['status'], Tournament.STATUS_DRAFT)
+
+    def test_organizer_can_create(self):
+        self.client.force_authenticate(user=self.organizer)
+        resp = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data['created_by_id'], self.organizer.id)
+
+    def test_regular_user_cannot_create(self):
+        self.client.force_authenticate(user=self.regular_user)
+        resp = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_unauthenticated_cannot_create(self):
+        resp = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_with_invalid_dates_fails(self):
+        self.client.force_authenticate(user=self.admin)
+        now = timezone.now()
+        data = {
+            'title': 'Bad',
+            'start_date': (now + timedelta(days=5)).isoformat(),
+            'end_date': (now + timedelta(days=3)).isoformat(),
+        }
+        resp = self.client.post(self.url, data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('end_date', resp.data.get('details', resp.data))
+
+    def test_create_with_min_teams_below_floor_fails(self):
+        self.client.force_authenticate(user=self.admin)
+        data = {**self.valid_data, 'min_teams': 1}
+        resp = self.client.post(self.url, data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('min_teams', resp.data.get('details', resp.data))
+
+    def test_create_returns_read_representation(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.post(self.url, self.valid_data, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertIn('registered_teams_count', resp.data)
+        self.assertIn('is_registration_open', resp.data)
+        self.assertIn('is_creator', resp.data)
+        self.assertTrue(resp.data['is_creator'])
+
+
+class TournamentListAPITests(APITestCase):
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            username='admin', email='admin@test.com', password='Pass1234!',
+            role='admin', is_staff=True, is_superuser=True,
+        )
+        self.regular_user = User.objects.create_user(
+            username='regular', email='regular@test.com', password='Pass1234!',
+            role='team',
+        )
+        self.url = reverse('tournament_list_create')
+
+        now = timezone.now()
+        self.draft = Tournament(title='Draft Cup', created_by=self.admin, status=Tournament.STATUS_DRAFT)
+        self.draft.save(skip_auto_status=True)
+
+        self.reg = Tournament(
+            title='Open Cup', created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            registration_start=now - timedelta(hours=1),
+            registration_end=now + timedelta(hours=5),
+            start_date=now + timedelta(days=2),
+            end_date=now + timedelta(days=5),
+        )
+        self.reg.save(skip_auto_status=True)
+
+        self.running = Tournament(
+            title='Running Cup', created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            start_date=now - timedelta(days=1),
+            end_date=now + timedelta(days=5),
+        )
+        self.running.save(skip_auto_status=True)
+
+    def test_admin_sees_drafts(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        titles = [t['title'] for t in resp.data]
+        self.assertIn('Draft Cup', titles)
+
+    def test_regular_user_does_not_see_draft(self):
+        self.client.force_authenticate(user=self.regular_user)
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        titles = [t['title'] for t in resp.data]
+        self.assertNotIn('Draft Cup', titles)
+
+    def test_creator_sees_own_draft(self):
+        creator = User.objects.create_user(
+            username='creator', email='creator@test.com', password='Pass1234!',
+            role='organizer',
+        )
+        draft = Tournament(title='My Draft', created_by=creator, status=Tournament.STATUS_DRAFT)
+        draft.save(skip_auto_status=True)
+
+        self.client.force_authenticate(user=creator)
+        resp = self.client.get(self.url)
+        titles = [t['title'] for t in resp.data]
+        self.assertIn('My Draft', titles)
+
+    def test_filter_by_status(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.get(self.url, {'status': 'running'})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(all(t['status'] == 'running' for t in resp.data))
+
+    def test_search_by_title(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.get(self.url, {'search': 'Open'})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]['title'], 'Open Cup')
+
+    def test_filter_registration_open(self):
+        self.client.force_authenticate(user=self.regular_user)
+        resp = self.client.get(self.url, {'registration_open': 'true'})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(all(t['is_registration_open'] for t in resp.data))
+
+    def test_ordering_by_title(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.get(self.url, {'ordering': 'title'})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        titles = [t['title'] for t in resp.data]
+        self.assertEqual(titles, sorted(titles))
+
+    def test_unauthenticated_fails(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TournamentRetrieveAPITests(APITestCase):
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            username='admin', email='admin@test.com', password='Pass1234!',
+            role='admin', is_staff=True, is_superuser=True,
+        )
+        self.regular_user = User.objects.create_user(
+            username='regular', email='regular@test.com', password='Pass1234!',
+            role='team',
+        )
+
+        self.draft = Tournament(title='Draft Cup', created_by=self.admin, status=Tournament.STATUS_DRAFT)
+        self.draft.save(skip_auto_status=True)
+
+        self.published = Tournament(
+            title='Published Cup', created_by=self.admin, status=Tournament.STATUS_REGISTRATION,
+            registration_start=timezone.now() - timedelta(hours=1),
+            registration_end=timezone.now() + timedelta(hours=5),
+            start_date=timezone.now() + timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=5),
+        )
+        self.published.save(skip_auto_status=True)
+
+    def test_admin_can_retrieve_draft(self):
+        self.client.force_authenticate(user=self.admin)
+        url = reverse('tournament_detail', kwargs={'pk': self.draft.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['title'], 'Draft Cup')
+
+    def test_regular_user_cannot_retrieve_draft(self):
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('tournament_detail', kwargs={'pk': self.draft.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_regular_user_can_retrieve_published(self):
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('tournament_detail', kwargs={'pk': self.published.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['title'], 'Published Cup')
+
+    def test_retrieve_has_computed_fields(self):
+        self.client.force_authenticate(user=self.admin)
+        url = reverse('tournament_detail', kwargs={'pk': self.published.pk})
+        resp = self.client.get(url)
+        self.assertIn('registered_teams_count', resp.data)
+        self.assertIn('is_registration_open', resp.data)
+        self.assertIn('can_register', resp.data)
+        self.assertIn('is_creator', resp.data)
+        self.assertTrue(resp.data['is_creator'])
+
+    def test_is_creator_false_for_other_user(self):
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('tournament_detail', kwargs={'pk': self.published.pk})
+        resp = self.client.get(url)
+        self.assertFalse(resp.data['is_creator'])
+
+
+class TournamentUpdateAPITests(APITestCase):
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            username='admin', email='admin@test.com', password='Pass1234!',
+            role='admin', is_staff=True, is_superuser=True,
+        )
+        self.organizer = User.objects.create_user(
+            username='organizer', email='organizer@test.com', password='Pass1234!',
+            role='organizer',
+        )
+        self.regular_user = User.objects.create_user(
+            username='regular', email='regular@test.com', password='Pass1234!',
+            role='team',
+        )
+
+        self.tournament = Tournament(
+            title='Cup', created_by=self.organizer,
+            status=Tournament.STATUS_REGISTRATION,
+            registration_start=timezone.now() - timedelta(hours=1),
+            registration_end=timezone.now() + timedelta(hours=5),
+            start_date=timezone.now() + timedelta(days=2),
+            end_date=timezone.now() + timedelta(days=5),
+        )
+        self.tournament.save(skip_auto_status=True)
+        self.url = reverse('tournament_detail', kwargs={'pk': self.tournament.pk})
+
+    def test_creator_can_update(self):
+        self.client.force_authenticate(user=self.organizer)
+        resp = self.client.patch(self.url, {'title': 'Updated Cup'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['title'], 'Updated Cup')
+
+    def test_admin_can_update(self):
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.patch(self.url, {'title': 'Admin Updated'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['title'], 'Admin Updated')
+
+    def test_other_user_cannot_update(self):
+        self.client.force_authenticate(user=self.regular_user)
+        resp = self.client.patch(self.url, {'title': 'Hacked'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_with_invalid_data_fails(self):
+        self.client.force_authenticate(user=self.organizer)
+        resp = self.client.patch(self.url, {'min_teams': 0}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_returns_read_representation(self):
+        self.client.force_authenticate(user=self.organizer)
+        resp = self.client.patch(self.url, {'title': 'Cup v2'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('registered_teams_count', resp.data)
+        self.assertIn('is_creator', resp.data)
+
+
+class TournamentDeleteAPITests(APITestCase):
+
+    def setUp(self):
+        self.admin = User.objects.create_user(
+            username='admin', email='admin@test.com', password='Pass1234!',
+            role='admin', is_staff=True, is_superuser=True,
+        )
+        self.organizer = User.objects.create_user(
+            username='organizer', email='organizer@test.com', password='Pass1234!',
+            role='organizer',
+        )
+        self.regular_user = User.objects.create_user(
+            username='regular', email='regular@test.com', password='Pass1234!',
+            role='team',
+        )
+
+    def _make_tournament(self, **overrides):
+        defaults = {
+            'title': 'Cup',
+            'created_by': self.organizer,
+            'status': Tournament.STATUS_DRAFT,
+        }
+        defaults.update(overrides)
+        t = Tournament(**defaults)
+        t.save(skip_auto_status=True)
+        return t
+
+    def test_creator_can_delete(self):
+        t = self._make_tournament()
+        self.client.force_authenticate(user=self.organizer)
+        resp = self.client.delete(reverse('tournament_detail', kwargs={'pk': t.pk}))
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Tournament.objects.filter(pk=t.pk).exists())
+
+    def test_admin_can_delete(self):
+        t = self._make_tournament()
+        self.client.force_authenticate(user=self.admin)
+        resp = self.client.delete(reverse('tournament_detail', kwargs={'pk': t.pk}))
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_other_user_cannot_delete(self):
+        t = self._make_tournament(status=Tournament.STATUS_REGISTRATION)
+        self.client.force_authenticate(user=self.regular_user)
+        resp = self.client.delete(reverse('tournament_detail', kwargs={'pk': t.pk}))
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/tournaments/urls.py
+++ b/backend/tournaments/urls.py
@@ -1,8 +1,15 @@
 from django.urls import path
 
-from .views import TournamentRegistrationView, TournamentStatusTransitionView
+from .views import (
+    TournamentDetailView,
+    TournamentListCreateView,
+    TournamentRegistrationView,
+    TournamentStatusTransitionView,
+)
 
 urlpatterns = [
+    path('', TournamentListCreateView.as_view(), name='tournament_list_create'),
+    path('<int:pk>/', TournamentDetailView.as_view(), name='tournament_detail'),
     path('<int:pk>/register/', TournamentRegistrationView.as_view(), name='tournament_register'),
     path('<int:pk>/status/', TournamentStatusTransitionView.as_view(), name='tournament_status'),
 ]

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -1,5 +1,8 @@
+from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404
-from rest_framework import status
+from django.utils import timezone
+from rest_framework import generics, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -10,11 +13,109 @@ from .serializers import (
     StatusTransitionSerializer,
     TournamentReadSerializer,
     TournamentTeamRegistrationSerializer,
+    TournamentWriteSerializer,
 )
 
 
 def is_platform_admin(user):
     return bool(user and user.is_authenticated and (user.is_superuser or user.role == 'admin'))
+
+
+ALLOWED_ORDERINGS = {'start_date', '-start_date', 'created_at', '-created_at', 'title', '-title'}
+
+
+class TournamentListCreateView(generics.ListCreateAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return TournamentWriteSerializer
+        return TournamentReadSerializer
+
+    def get_queryset(self):
+        user = self.request.user
+        qs = Tournament.objects.select_related('created_by').order_by('-created_at')
+
+        if is_platform_admin(user):
+            pass
+        else:
+            qs = qs.filter(Q(created_by=user) | ~Q(status=Tournament.STATUS_DRAFT))
+
+        params = self.request.query_params
+
+        status_filter = params.get('status')
+        if status_filter:
+            qs = qs.filter(status=status_filter)
+
+        search = params.get('search')
+        if search:
+            qs = qs.filter(title__icontains=search)
+
+        created_by = params.get('created_by')
+        if created_by:
+            qs = qs.filter(created_by_id=created_by)
+
+        if params.get('registration_open') == 'true':
+            now = timezone.now()
+            qs = qs.filter(
+                status=Tournament.STATUS_REGISTRATION,
+                registration_start__lte=now,
+                registration_end__gte=now,
+            )
+
+        start_date_from = params.get('start_date_from')
+        if start_date_from:
+            qs = qs.filter(start_date__gte=start_date_from)
+
+        start_date_to = params.get('start_date_to')
+        if start_date_to:
+            qs = qs.filter(start_date__lte=start_date_to)
+
+        ordering = params.get('ordering')
+        if ordering and ordering in ALLOWED_ORDERINGS:
+            qs = qs.order_by(ordering)
+
+        return qs
+
+    def perform_create(self, serializer):
+        user = self.request.user
+        if user.role not in ('admin', 'organizer') and not user.is_superuser:
+            raise PermissionDenied('Only admins and organizers can create tournaments.')
+        serializer.save(created_by=user)
+
+
+class TournamentDetailView(generics.RetrieveUpdateDestroyAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_serializer_class(self):
+        if self.request.method in ('PUT', 'PATCH'):
+            return TournamentWriteSerializer
+        return TournamentReadSerializer
+
+    def get_queryset(self):
+        return Tournament.objects.select_related('created_by')
+
+    def get_object(self):
+        obj = super().get_object()
+        user = self.request.user
+        if obj.status == Tournament.STATUS_DRAFT and obj.created_by_id != user.id and not is_platform_admin(user):
+            raise Http404
+        return obj
+
+    def _assert_owner_or_admin(self, obj):
+        user = self.request.user
+        if obj.created_by_id != user.id and not is_platform_admin(user):
+            raise PermissionDenied('Only the tournament creator or a platform admin can modify this tournament.')
+
+    def update(self, request, *args, **kwargs):
+        obj = self.get_object()
+        self._assert_owner_or_admin(obj)
+        return super().update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        obj = self.get_object()
+        self._assert_owner_or_admin(obj)
+        return super().destroy(request, *args, **kwargs)
 
 
 class TournamentRegistrationView(APIView):


### PR DESCRIPTION
**Serializers**
- Added TournamentWriteSerializer with clean() validation and to_representation() returning read format
- Added can_register and is_creator computed fields to TournamentReadSerializer

**Views**
- Added TournamentListCreateView with filtering (status, search, created_by, registration_open, start_date_from/to) and ordering (start_date, created_at, title)
- Added TournamentDetailView with retrieve, update, and delete support
- Draft tournaments are hidden from non-creator and non-admin users (404)
- Create restricted to admin and organizer roles
- Update/delete restricted to tournament creator and platform admin

**URLs**
- Added GET/POST /api/tournaments/ for list and create
- Added GET/PUT/PATCH/DELETE /api/tournaments/<id>/ for detail operations

**Tests**
- TournamentCreateAPITests: admin/organizer can create, regular user cannot, validation errors for invalid dates and min_teams, response includes read representation
- TournamentListAPITests: admin sees drafts, regular user does not, creator sees own drafts, filter by status/search/registration_open, ordering by title
- TournamentRetrieveAPITests: admin retrieves draft, regular user gets 404 for draft, computed fields present, is_creator correctness
- TournamentUpdateAPITests: creator and admin can update, other user gets 403, validation on invalid data, response includes read representation
- TournamentDeleteAPITests: creator and admin can delete, other user gets 403