### PR TITLE
Fix/tournaments api

### DIFF
--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -13,6 +13,7 @@
 | **Редагувати турнір** | PATCH/DEL| `/api/tournaments/manage/{id}/` | Admin |
 | **Відкрити реєстрацію**| POST | `/api/tournaments/{id}/start-registration/` | Admin |
 | **Доступні команди капітана** | GET | `/api/tournaments/{id}/eligible-teams/` | Auth |
+| **Зареєстровані команди турніру** | GET | `/api/tournaments/{id}/teams/` | Auth |
 | **Активний турнір команди** | GET | `/api/tournaments/active/?team_id={id}` | Auth |
 | **Реєстрація команди** | POST | `/api/tournaments/{id}/register-team/` | Капітан |
 | **Деталі/Зміна реєстрації**| GET/PATCH | `/api/tournaments/{id}/registrations/{reg_id}/` | Admin |
@@ -87,6 +88,33 @@
 ```
 > Повертає тільки команди, де `team.captain_id == request.user.id`.
 > Додаткових перевірок eligibility тут немає (перевірки колізій виконуються на етапі реєстрації).
+
+**Зареєстровані команди турніру — GET `/api/tournaments/{id}/teams/`**
+```json
+[
+  {
+    "id": 1,
+    "team": {
+      "id": 10,
+      "name": "Team Alpha",
+      "is_public": true
+    },
+    "is_active": true
+  },
+  {
+    "id": 2,
+    "team": {
+      "id": 11,
+      "name": "Team Beta",
+      "is_public": false
+    },
+    "is_active": false
+  }
+]
+```
+> Повертає всі реєстрації команд у конкретному турнірі з ознакою активності `is_active`.
+> Доступний query-параметр `?only_active=true`, щоб повернути тільки активні команди (`is_active=true`).
+> Якщо турнір не існує — `404`.
 
 **Активний турнір команди — GET `/api/tournaments/active/?team_id={id}`**
 ```json

--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -25,7 +25,14 @@
 | **Мої роботи** | GET | `/api/tournaments/submissions/` | Команда |
 | **Подати роботу** | POST | `/api/tournaments/submissions/` | Команда |
 | **Деталі/Зміна роботи** | GET/PATCH | `/api/tournaments/submissions/{id}/` | Команда |
-| **Поточне завдання** | GET | `/api/tournaments/current-task/` | Учасники |
+| **Поточне завдання** | GET | `/api/tournaments/current-task/?tournament_id={id}` *(опц.)* | Учасники |
+
+> **`GET /api/tournaments/current-task/`**
+> - Повертає перший активний раунд (`status=active`) серед турнірів зі статусом `running`, відсортований за `end_date`, `id`.
+> - Опційний фільтр: `tournament_id` (query param).
+> - Доступ: лише авторизовані користувачі, які є `admin` або учасниками/капітанами команди.
+> - Якщо активного раунду немає — `404` (`No active round is available right now.`).
+> - Поля відповіді: `id`, `tournament_id`, `tournament_name`, `name`, `task`, `deadline`, `must_have_requirements`, `tech_requirements`.
 
 ### 2. Раунди 
 

--- a/backend/tournaments/serializers.py
+++ b/backend/tournaments/serializers.py
@@ -332,3 +332,11 @@ class TournamentTeamRegistrationUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = TournamentTeamRegistration
         fields = ('is_active',)
+
+
+class TournamentTeamRegistrationListSerializer(serializers.ModelSerializer):
+    team = TeamSummarySerializer(read_only=True)
+
+    class Meta:
+        model = TournamentTeamRegistration
+        fields = ('id', 'team', 'is_active')

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -423,6 +423,107 @@ class TournamentApiTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_tournament_teams_returns_registrations_with_is_active(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        second_user = User.objects.create_user(
+            username='second-captain',
+            email='second-captain@example.com',
+            password='StrongPass123!',
+        )
+        second_team = Team.objects.create(
+            name='Second Team',
+            email='second-team@example.com',
+            captain=second_user,
+        )
+        TeamMember.objects.create(team=second_team, user=second_user)
+
+        TournamentTeamRegistration.objects.create(
+            tournament=tournament,
+            team=self.team,
+            created_by=self.captain,
+            is_active=True,
+        )
+        inactive_registration = TournamentTeamRegistration.objects.create(
+            tournament=tournament,
+            team=second_team,
+            created_by=second_user,
+            is_active=False,
+        )
+
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_teams', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['team']['id'], self.team.id)
+        self.assertEqual(response.data[0]['team']['name'], self.team.name)
+        self.assertTrue(response.data[0]['is_active'])
+        self.assertEqual(response.data[1]['id'], inactive_registration.id)
+        self.assertFalse(response.data[1]['is_active'])
+
+    def test_tournament_teams_filters_only_active(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        second_user = User.objects.create_user(
+            username='third-captain',
+            email='third-captain@example.com',
+            password='StrongPass123!',
+        )
+        second_team = Team.objects.create(
+            name='Third Team',
+            email='third-team@example.com',
+            captain=second_user,
+        )
+        TeamMember.objects.create(team=second_team, user=second_user)
+
+        active_registration = TournamentTeamRegistration.objects.create(
+            tournament=tournament,
+            team=self.team,
+            created_by=self.captain,
+            is_active=True,
+        )
+        TournamentTeamRegistration.objects.create(
+            tournament=tournament,
+            team=second_team,
+            created_by=second_user,
+            is_active=False,
+        )
+
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_teams', kwargs={'pk': tournament.id})
+        response = self.client.get(url, {'only_active': 'true'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], active_registration.id)
+        self.assertTrue(response.data[0]['is_active'])
+
+    def test_tournament_teams_returns_404_for_missing_tournament(self):
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_teams', kwargs={'pk': 999999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_tournament_teams_requires_authentication(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        url = reverse('tournament_teams', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_sync_time_based_statuses(self):
         from .services import sync_time_based_statuses
         

--- a/backend/tournaments/urls.py
+++ b/backend/tournaments/urls.py
@@ -13,6 +13,7 @@ from .views import (
     TournamentCreateView,
     TournamentDetailView,
     TournamentListView,
+    TournamentTeamsView,
     TournamentEligibleTeamsView,
     TournamentStartRegistrationView,
     TournamentTeamRegistrationCreateView,
@@ -32,6 +33,7 @@ urlpatterns = [
     ),
     path('<int:pk>/register-team/', TournamentTeamRegistrationCreateView.as_view(), name='tournament_register_team'),
     path('<int:pk>/eligible-teams/', TournamentEligibleTeamsView.as_view(), name='tournament_eligible_teams'),
+    path('<int:pk>/teams/', TournamentTeamsView.as_view(), name='tournament_teams'),
     path('active/', TeamActiveTournamentView.as_view(), name='team_active_tournament'),
     path(
         '<int:pk>/registrations/<int:registration_pk>/',

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -27,6 +27,7 @@ from .serializers import (
     TournamentAdminSerializer,
     TournamentPublicSerializer,
     TournamentTeamRegistrationCreateSerializer,
+    TournamentTeamRegistrationListSerializer,
     TournamentTeamRegistrationSerializer,
     TournamentTeamRegistrationUpdateSerializer,
 )
@@ -192,6 +193,24 @@ class TournamentEligibleTeamsView(APIView):
             .order_by('id')
         )
         return Response(list(teams), status=status.HTTP_200_OK)
+
+
+class TournamentTeamsView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, pk):
+        get_object_or_404(Tournament, pk=pk)
+
+        queryset = TournamentTeamRegistration.objects.filter(
+            tournament_id=pk,
+        ).select_related('team')
+
+        only_active = request.query_params.get('only_active')
+        if only_active and only_active.lower() == 'true':
+            queryset = queryset.filter(is_active=True)
+
+        serializer = TournamentTeamRegistrationListSerializer(queryset.order_by('id'), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class TeamActiveTournamentView(APIView):


### PR DESCRIPTION
Додано endpoint:

- **Зареєстровані команди турніру | GET |  /api/tournaments/{id}/teams/**

Зареєстровані команди турніру — GET /api/tournaments/{id}/teams/

```
[
  {
    "id": 1,
    "team": {
      "id": 10,
      "name": "Team Alpha",
      "is_public": true
    },
    "is_active": true
  },
  {
    "id": 2,
    "team": {
      "id": 11,
      "name": "Team Beta",
      "is_public": false
    },
    "is_active": false
  }
]
```
Повертає всі реєстрації команд у конкретному турнірі з ознакою активності is_active. Доступний query-параметр ?only_active=true, щоб повернути тільки активні команди (is_active=true). Якщо турнір не існує — 404.

Оновлено: api_cheat_sheet.md