### PR TITLE
Added Tournament pagination, filtering. Added rounds_count setter to fix AttributeError

### DIFF
--- a/backend/tournaments/models.py
+++ b/backend/tournaments/models.py
@@ -44,6 +44,10 @@ class Tournament(models.Model):
     def rounds_count(self):
         return self.__dict__.get('rounds_count') or self.rounds.count()
 
+    @rounds_count.setter
+    def rounds_count(self, value):
+        self.__dict__['rounds_count'] = value
+
     def clean(self):
         errors = {}
 

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -544,6 +544,214 @@ class TournamentApiTests(APITestCase):
         round_obj.refresh_from_db()
         self.assertEqual(round_obj.status, Round.STATUS_SUBMISSION_CLOSED)
 
+    def test_tournament_list_pagination_response_shape(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            **self.tournament_data
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('data', response.data)
+        self.assertIn('total', response.data)
+        self.assertIsInstance(response.data['data'], list)
+        self.assertIsInstance(response.data['total'], int)
+
+    def test_tournament_list_pagination_page_size(self):
+        for i in range(25):
+            Tournament.objects.create(
+                created_by=self.admin,
+                status=Tournament.STATUS_REGISTRATION,
+                name=f'Tournament {i}',
+                description=f'Desc {i}',
+                start_date=timezone.now() + timezone.timedelta(days=1),
+                end_date=timezone.now() + timezone.timedelta(days=10),
+            )
+
+        url = reverse('tournaments')
+        response = self.client.get(url, {'page': '1'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['total'], 25)
+        self.assertEqual(len(response.data['data']), 20)
+
+        response2 = self.client.get(url, {'page': '2'})
+        self.assertEqual(len(response2.data['data']), 5)
+
+    def test_tournament_list_pagination_default_page(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            **self.tournament_data
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url)
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(len(response.data['data']), 1)
+
+    def test_tournament_list_filter_by_search_query(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Alpha Cup',
+            description='First tournament',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Beta Cup',
+            description='Second tournament',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url, {'searchQuery': 'Alpha'})
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Alpha Cup')
+
+    def test_tournament_list_filter_by_search_query_description(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Alpha Cup',
+            description='Unique keyword here',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Beta Cup',
+            description='Other description',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url, {'searchQuery': 'Unique keyword'})
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Alpha Cup')
+
+    def test_tournament_list_filter_by_status(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Reg Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            name='Running Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url, {'status': 'registration'})
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Reg Tournament')
+
+    def test_tournament_list_filter_by_multiple_statuses(self):
+        reg_tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Reg Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        running_tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            name='Running Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Round.objects.create(
+            tournament=running_tournament,
+            position=1,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(days=5),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_FINISHED,
+            name='Finished Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url, {'status': 'registration,running'})
+        self.assertEqual(response.data['total'], 2)
+
+    def test_tournament_list_filter_by_start_at(self):
+        today = timezone.now().date()
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Today Start',
+            description='desc',
+            start_date=timezone.now().replace(hour=10, minute=0, second=0),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Tomorrow Start',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url, {'startAt': today.isoformat()})
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Today Start')
+
+    def test_tournament_list_hides_draft_for_anonymous(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_DRAFT,
+            name='Draft Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_REGISTRATION,
+            name='Public Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        url = reverse('tournaments')
+        response = self.client.get(url)
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Public Tournament')
+
+    def test_tournament_list_shows_draft_to_admin(self):
+        Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_DRAFT,
+            name='Draft Tournament',
+            description='desc',
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            end_date=timezone.now() + timezone.timedelta(days=10),
+        )
+        self.client.force_authenticate(user=self.admin)
+        url = reverse('tournaments')
+        response = self.client.get(url)
+        self.assertEqual(response.data['total'], 1)
+        self.assertEqual(response.data['data'][0]['name'], 'Draft Tournament')
+
     def test_round_dates_validation(self):
         tournament = Tournament.objects.create(
             created_by=self.admin,

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -579,6 +579,41 @@ class TournamentApiTests(APITestCase):
         response2 = self.client.get(url, {'page': '2'})
         self.assertEqual(len(response2.data['data']), 5)
 
+    def test_tournament_list_pagination_custom_page_size(self):
+        for i in range(15):
+            Tournament.objects.create(
+                created_by=self.admin,
+                status=Tournament.STATUS_REGISTRATION,
+                name=f'Tournament {i}',
+                description=f'Desc {i}',
+                start_date=timezone.now() + timezone.timedelta(days=1),
+                end_date=timezone.now() + timezone.timedelta(days=10),
+            )
+
+        url = reverse('tournaments')
+        response = self.client.get(url, {'page': '1', 'pageSize': '5'})
+        self.assertEqual(response.data['total'], 15)
+        self.assertEqual(len(response.data['data']), 5)
+
+        response2 = self.client.get(url, {'page': '3', 'pageSize': '5'})
+        self.assertEqual(len(response2.data['data']), 5)
+
+    def test_tournament_list_pagination_max_page_size(self):
+        for i in range(150):
+            Tournament.objects.create(
+                created_by=self.admin,
+                status=Tournament.STATUS_REGISTRATION,
+                name=f'Tournament {i}',
+                description=f'Desc {i}',
+                start_date=timezone.now() + timezone.timedelta(days=1),
+                end_date=timezone.now() + timezone.timedelta(days=10),
+            )
+
+        url = reverse('tournaments')
+        response = self.client.get(url, {'page': '1', 'pageSize': '9999'})
+        self.assertEqual(response.data['total'], 150)
+        self.assertEqual(len(response.data['data']), 100)
+
     def test_tournament_list_pagination_default_page(self):
         Tournament.objects.create(
             created_by=self.admin,

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -70,7 +70,8 @@ class SyncStatusesMixin:
 
 class TournamentListView(SyncStatusesMixin, APIView):
     permission_classes = [AllowAny]
-    PAGE_SIZE = 20
+    DEFAULT_PAGE_SIZE = 20
+    MAX_PAGE_SIZE = 100
 
     def _get_base_queryset(self):
         user = self.request.user
@@ -121,8 +122,12 @@ class TournamentListView(SyncStatusesMixin, APIView):
         total = queryset.count()
 
         page = int(request.query_params.get('page', 1))
-        offset = (page - 1) * self.PAGE_SIZE
-        page_queryset = queryset[offset:offset + self.PAGE_SIZE]
+        page_size = min(
+            int(request.query_params.get('pageSize', self.DEFAULT_PAGE_SIZE)),
+            self.MAX_PAGE_SIZE,
+        )
+        offset = (page - 1) * page_size
+        page_queryset = queryset[offset:offset + page_size]
 
         serializer = TournamentPublicSerializer(page_queryset, many=True)
         return Response({'data': serializer.data, 'total': total})

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -68,12 +68,11 @@ class SyncStatusesMixin:
         return super().initial(request, *args, **kwargs)
 
 
-class TournamentListView(SyncStatusesMixin, generics.ListAPIView):
-    queryset = get_tournament_queryset()
+class TournamentListView(SyncStatusesMixin, APIView):
     permission_classes = [AllowAny]
-    serializer_class = TournamentPublicSerializer
+    PAGE_SIZE = 20
 
-    def get_queryset(self):
+    def _get_base_queryset(self):
         user = self.request.user
         base_queryset = get_tournament_queryset()
         published_filter = ~Q(status=Tournament.STATUS_DRAFT)
@@ -85,6 +84,48 @@ class TournamentListView(SyncStatusesMixin, generics.ListAPIView):
             return base_queryset.filter(published_filter | Q(created_by=user))
 
         return base_queryset.filter(published_filter)
+
+    def _apply_filters(self, queryset):
+        params = self.request.query_params
+
+        search_query = params.get('searchQuery')
+        if search_query:
+            queryset = queryset.filter(
+                Q(name__icontains=search_query) | Q(description__icontains=search_query)
+            )
+
+        status_param = params.get('status')
+        if status_param:
+            statuses = [s.strip() for s in status_param.split(',') if s.strip()]
+            if statuses:
+                queryset = queryset.filter(status__in=statuses)
+
+        start_at = params.get('startAt')
+        if start_at:
+            queryset = queryset.filter(start_date__date=start_at)
+
+        end_at = params.get('endAt')
+        if end_at:
+            queryset = queryset.filter(end_date__date=end_at)
+
+        created_at = params.get('createdAt')
+        if created_at:
+            queryset = queryset.filter(created_at__date=created_at)
+
+        return queryset
+
+    def get(self, request):
+        queryset = self._get_base_queryset()
+        queryset = self._apply_filters(queryset)
+
+        total = queryset.count()
+
+        page = int(request.query_params.get('page', 1))
+        offset = (page - 1) * self.PAGE_SIZE
+        page_queryset = queryset[offset:offset + self.PAGE_SIZE]
+
+        serializer = TournamentPublicSerializer(page_queryset, many=True)
+        return Response({'data': serializer.data, 'total': total})
 
 
 class TournamentDetailView(SyncStatusesMixin, generics.RetrieveAPIView):


### PR DESCRIPTION
**TournamentListView**
- Refactored from `generics.ListAPIView` to `APIView` with custom response format `{data, total}`
- Added pagination: `page` query param (default 1, page size 20)
- Added filtering: `searchQuery` (name/description icontains), `status` (comma-separated exact), `startAt`, `endAt`, `createdAt` (date exact)
- Preserved existing visibility logic (draft hidden from non-admins)

**Tournament model**
- Added rounds_count setter to fix `AttributeError` when Django sets annotated value via `setattr()`

**Tests**
- test_tournament_list_pagination_response_shape — verifies `{data, total}` response structure
- test_tournament_list_pagination_page_size — verifies 20 items per page, correct pagination across pages
- test_tournament_list_pagination_default_page — verifies default page=1 behavior
- test_tournament_list_filter_by_search_query — verifies name icontains filter
- test_tournament_list_filter_by_search_query_description — verifies description icontains filter
- test_tournament_list_filter_by_status — verifies single status filter
- test_tournament_list_filter_by_multiple_statuses — verifies comma-separated status filter
- test_tournament_list_filter_by_start_at — verifies startAt date filter
- test_tournament_list_hides_draft_for_anonymous — verifies draft tournaments hidden from anonymous
- test_tournament_list_shows_draft_to_admin — verifies draft tournaments visible to admin