### PR TITLE
refactor(tournament): enhance team registration serializer to include…

### DIFF
--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -93,21 +93,16 @@
 ```json
 [
   {
-    "id": 1,
-    "team": {
-      "id": 10,
-      "name": "Team Alpha",
-      "is_public": true
-    },
+    "id": 10,
+    "name": "Team Alpha",
+    "members_count": 3,
+    "is_public": true,
     "is_active": true
   },
   {
-    "id": 2,
-    "team": {
-      "id": 11,
-      "name": "Team Beta",
-      "is_public": false
-    },
+    "id": 11,
+    "name": "Team Beta",
+    "is_public": false,
     "is_active": false
   }
 ]

--- a/backend/tournaments/serializers.py
+++ b/backend/tournaments/serializers.py
@@ -335,8 +335,14 @@ class TournamentTeamRegistrationUpdateSerializer(serializers.ModelSerializer):
 
 
 class TournamentTeamRegistrationListSerializer(serializers.ModelSerializer):
-    team = TeamSummarySerializer(read_only=True)
-
+    id = serializers.IntegerField(source='team.id')
+    name = serializers.CharField(source='team.name')
+    is_public = serializers.BooleanField(source='team.is_public')
+    members_count = serializers.SerializerMethodField()
+ 
     class Meta:
         model = TournamentTeamRegistration
-        fields = ('id', 'team', 'is_active')
+        fields = ('id', 'name', 'members_count', 'is_public', 'is_active')
+ 
+    def get_members_count(self, obj):
+        return obj.team.team_members.count() + 1  # members + captain

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -243,21 +243,20 @@ class TournamentEligibleTeamsView(APIView):
 
 class TournamentTeamsView(APIView):
     permission_classes = [IsAuthenticated]
-
+ 
     def get(self, request, pk):
         get_object_or_404(Tournament, pk=pk)
-
+ 
         queryset = TournamentTeamRegistration.objects.filter(
             tournament_id=pk,
-        ).select_related('team')
-
+        ).select_related('team').prefetch_related('team__team_members')
+ 
         only_active = request.query_params.get('only_active')
         if only_active and only_active.lower() == 'true':
             queryset = queryset.filter(is_active=True)
-
+ 
         serializer = TournamentTeamRegistrationListSerializer(queryset.order_by('id'), many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-
 
 class TeamActiveTournamentView(APIView):
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
```
[
  {
    "id":2,
    "name":"kokogamba",
    "members_count":2,
    "is_public":true,
    "is_active":true
  }
]
```
Тепер такі дані повертає `/api/tournaments/1/teams/`