### PR TITLE
feat: add organizer role permissions for tournament creation and update tests

### DIFF
--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -11,7 +11,7 @@
 | :--- | :--- | :--- | :--- |
 | **Список турнірів** | GET | `/api/tournaments/` | Всі |
 | **Деталі турніру** | GET | `/api/tournaments/{id}/` | Всі |
-| **Створити турнір** | POST | `/api/tournaments/manage/` | Admin |
+| **Створити турнір** | POST | `/api/tournaments/manage/` | Admin, Organizer |
 | **Редагувати турнір** | PATCH/DEL| `/api/tournaments/manage/{id}/` | Admin |
 | **Відкрити реєстрацію**| POST | `/api/tournaments/{id}/start-registration/` | Admin |
 | **Реєстрація команди** | POST | `/api/tournaments/{id}/register-team/` | Капітан |

--- a/backend/accounts/utils/permissions.py
+++ b/backend/accounts/utils/permissions.py
@@ -1,2 +1,26 @@
+class Permission:
+    CREATE_TOURNAMENT = 'create_tournament'
+
+
+ROLE_PERMISSIONS = {
+    'admin': {
+        Permission.CREATE_TOURNAMENT,
+    },
+    'organizer': {
+        Permission.CREATE_TOURNAMENT,
+    },
+    'team': set(),
+    'jury': set(),
+}
+
+
 def is_platform_admin(user):
     return bool(user and user.is_authenticated and (user.is_superuser or user.role == 'admin'))
+
+
+def has_permission(user, permission):
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    return permission in ROLE_PERMISSIONS.get(user.role, set())

--- a/backend/tournaments/permissions.py
+++ b/backend/tournaments/permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.permissions import BasePermission
 from django.db.models import Q
 
-from accounts.utils.permissions import is_platform_admin
+from accounts.utils.permissions import Permission, has_permission, is_platform_admin
 from teams.models import Team, TeamMember
 
 
@@ -10,6 +10,13 @@ class IsPlatformAdminPermission(BasePermission):
 
     def has_permission(self, request, view):
         return is_platform_admin(request.user)
+
+
+class CanCreateTournamentPermission(BasePermission):
+    message = 'Create tournament permission is required.'
+
+    def has_permission(self, request, view):
+        return has_permission(request.user, Permission.CREATE_TOURNAMENT)
 
 
 class IsTeamMemberPermission(BasePermission):

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -23,6 +23,12 @@ class TournamentApiTests(APITestCase):
             email='captain@example.com',
             password='StrongPass123!',
         )
+        self.organizer = User.objects.create_user(
+            username='organizer',
+            email='organizer@example.com',
+            password='StrongPass123!',
+            role='organizer',
+        )
         self.team = Team.objects.create(
             name='Test Team',
             email='test@example.com',
@@ -43,6 +49,15 @@ class TournamentApiTests(APITestCase):
         url = reverse('tournament_manage_create')
         response = self.client.post(url, self.tournament_data, format='json')
         
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Tournament.objects.count(), 1)
+        self.assertEqual(Round.objects.count(), 2)
+
+    def test_organizer_can_create_tournament(self):
+        self.client.force_authenticate(user=self.organizer)
+        url = reverse('tournament_manage_create')
+        response = self.client.post(url, self.tournament_data, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Tournament.objects.count(), 1)
         self.assertEqual(Round.objects.count(), 2)

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -8,6 +8,7 @@ from rest_framework.views import APIView
 
 from .models import Round, Submission, Tournament
 from .permissions import (
+    CanCreateTournamentPermission,
     IsJuryPermission,
     IsPlatformAdminOrTeamMemberPermission,
     IsPlatformAdminPermission,
@@ -98,7 +99,7 @@ class TournamentDetailView(SyncStatusesMixin, generics.RetrieveAPIView):
 
 
 class TournamentCreateView(generics.CreateAPIView):
-    permission_classes = [IsAuthenticated, IsPlatformAdminPermission]
+    permission_classes = [IsAuthenticated, CanCreateTournamentPermission]
     serializer_class = TournamentAdminSerializer
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
Додано доступ для ролі organizer до створення турнірів через існуючу систему permissions.

Зміни:

Додано permission CREATE_TOURNAMENT.
Надано цей permission ролям admin та organizer.
Оновлено endpoint створення турніру, щоб він використовував permission-based перевірку.
Додано тест для перевірки, що organizer може створювати турніри.
Оновлено API cheat sheet.
Результат:

Admin і надалі може створювати турніри.
Organizer тепер може створювати турніри.
Інші ролі не мають доступу.