### PR TITLE
Restrict jury assignment management endpoints to round managers

### DIFF
--- a/backend/evaluation/views.py
+++ b/backend/evaluation/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from tournaments.models import Round
-from tournaments.permissions import CanSetResults
+from tournaments.permissions import CanManageAssignments, CanSetResults
 from .services import get_available_jury, replace_round_jury_assignments, try_auto_evaluate_round
 
 from .models import JuryAssignment, SubmissionEvaluation
@@ -53,7 +53,7 @@ class JuryEvaluationDetailView(generics.RetrieveUpdateDestroyAPIView):
 
 
 class AdminRoundAssignmentView(APIView):
-    permission_classes = [IsAuthenticated, CanSetResults]
+    permission_classes = [IsAuthenticated, CanManageAssignments]
 
     def post(self, request, pk):
         round_obj = get_object_or_404(Round, pk=pk)
@@ -67,7 +67,7 @@ class AdminRoundAssignmentView(APIView):
 
 
 class AvailableJuryListView(APIView):
-    permission_classes = [IsAuthenticated, CanSetResults]
+    permission_classes = [IsAuthenticated, CanManageAssignments]
 
     def get(self, request, pk):
         round_obj = get_object_or_404(Round, pk=pk)

--- a/backend/tournaments/permissions.py
+++ b/backend/tournaments/permissions.py
@@ -48,6 +48,10 @@ class CanSetResults(HasTournamentPermission):
     required_permission = Permission.SET_RESULTS
 
 
+class CanManageAssignments(HasTournamentPermission):
+    required_permission = Permission.MANAGE_ROUNDS
+
+
 class CanManageRoundsOrReadOnly(HasTournamentPermissionOrReadOnly):
     required_permission = Permission.MANAGE_ROUNDS
 


### PR DESCRIPTION
Додано дозвіл `CanManageAssignments`.
Оновлено `backend/evaluation/views.py`:
`AdminRoundAssignmentView` тепер вимагає `CanManageAssignments`.
`AvailableJuryListView` тепер вимагає `CanManageAssignments`.
Кінцеві точки оцінювання журі (CanSetResults) збережено незмінними, щоб присяжні все ще могли надсилати/оновлювати свої призначені оцінки.