### PR TITLE
Feature/submissions api

### DIFF
--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -29,7 +29,7 @@
 | **Почати раунд** | POST | `/api/tournaments/rounds/{id}/start/` | Admin |
 | **Закрити прийом робіт**| POST | `/api/tournaments/rounds/{id}/close-submissions/` | Admin |
 | **Фіналізація оцінок** | POST | `/api/tournaments/rounds/{id}/mark-evaluated/` | Admin |
-| **Всі роботи турніру** | GET | `/api/tournaments/{id}/submissions/` | Auth (журі/адмін) |
+| **Роботи моїх команд у турнірі** | GET | `/api/tournaments/{id}/submissions/` | Лише капітан (автофільтр) |
 | **Всі роботи раунду** | GET | `/api/tournaments/rounds/{id}/submissions/` | Auth (журі/адмін) |
 | **Мої роботи** | GET | `/api/tournaments/submissions/` | Команда |
 | **Подати роботу** | POST | `/api/tournaments/submissions/` | Лише капітан команди |
@@ -225,7 +225,7 @@
 
 ### 3. Роботи (Команда)
 
-**Всі роботи турніру (Jury/Admin) — GET `/api/tournaments/{id}/submissions/`**
+**Роботи моїх команд у турнірі (Captain auto-filter) — GET `/api/tournaments/{id}/submissions/`**
 ```json
 [
   {
@@ -250,7 +250,9 @@
   }
 ]
 ```
-> Повертає всі submissions усіх раундів вказаного турніру, відсортовані за `updated_at` (спадання).
+> Повертає submissions усіх раундів вказаного турніру тільки для команд, де `request.user` є капітаном.
+> Не потрібно передавати `team_id` чи інші фільтри: фільтрація виконується на бекенді автоматично.
+> Якщо користувач не є капітаном жодної команди в турнірі — повертається порожній список `[]`.
 > Якщо турнір не існує — `404`.
 
 **Всі роботи раунду (Jury/Admin) — GET `/api/tournaments/rounds/{id}/submissions/`**

--- a/api_cheat_sheet.md
+++ b/api_cheat_sheet.md
@@ -5,6 +5,7 @@
 - `POST /api/teams/` -> `Auth`, but `admin` and `superuser` are denied (`403`).
 - `PUT/PATCH/DELETE /api/teams/{id}/` -> `Auth + captain rules`, but `admin` and `superuser` are denied (`403`).
 - `POST /api/tournaments/{id}/register-team/` -> `Auth + tournament registration rules`, but `admin` and `superuser` are denied (`403`).
+- `POST/PATCH /api/tournaments/submissions/` -> only team captain can create/update submission (`400` if not captain).
 
 ---
 
@@ -31,8 +32,8 @@
 | **Всі роботи турніру** | GET | `/api/tournaments/{id}/submissions/` | Auth (журі/адмін) |
 | **Всі роботи раунду** | GET | `/api/tournaments/rounds/{id}/submissions/` | Auth (журі/адмін) |
 | **Мої роботи** | GET | `/api/tournaments/submissions/` | Команда |
-| **Подати роботу** | POST | `/api/tournaments/submissions/` | Команда |
-| **Деталі/Зміна роботи** | GET/PATCH | `/api/tournaments/submissions/{id}/` | Команда |
+| **Подати роботу** | POST | `/api/tournaments/submissions/` | Лише капітан команди |
+| **Деталі/Зміна роботи** | GET/PATCH | `/api/tournaments/submissions/{id}/` | GET: Команда, PATCH: Лише капітан |
 | **Поточне завдання** | GET | `/api/tournaments/current-task/?tournament_id={id}` *(опц.)* | Учасники |
 | **Список подій** | GET | `/api/tournaments/events/?tournament={id}` *(опц.)* | Всі |
 | **Деталі події** | GET | `/api/tournaments/events/{id}/` | Всі |
@@ -266,6 +267,8 @@
   "description": "Ready for review"
 }
 ```
+> Дозволено тільки якщо `request.user == team.captain`.
+> Якщо запит робить не капітан, повертається `400` з помилкою по полю `team`.
 
 **Редагування роботи — PATCH `/api/tournaments/submissions/{id}/`**
 ```json
@@ -274,6 +277,8 @@
   "description": "Updated submission notes"
 }
 ```
+> Редагувати submission може тільки капітан відповідної команди.
+> Перегляд (`GET`) лишається доступним для капітана та учасників цієї команди.
 
 ### 4. Розклад / Події (Admin)
 

--- a/backend/tournaments/models.py
+++ b/backend/tournaments/models.py
@@ -250,6 +250,9 @@ class Submission(models.Model):
         if self.round and self.round.status != Round.STATUS_ACTIVE:
             errors['round'] = 'Round is closed for submissions.'
 
+        if self.team_id and self.created_by_id and self.team.captain_id != self.created_by_id:
+            errors['team'] = 'Only team captain can create or update submissions.'
+
         if errors:
             raise ValidationError(errors)
 
@@ -333,4 +336,3 @@ class Event(models.Model):
 
     def __str__(self):
         return f'{self.tournament_id}:{self.title}'
-

--- a/backend/tournaments/serializers.py
+++ b/backend/tournaments/serializers.py
@@ -241,8 +241,8 @@ class SubmissionSerializer(serializers.ModelSerializer):
             if 'round' in attrs and attrs['round'].id != instance.round_id:
                 errors['round'] = 'round cannot be changed.'
 
-        if team and user and not TeamMember.objects.filter(team=team, user=user).exists() and team.captain_id != user.id:
-            errors['team'] = 'You are not a member of this team.'
+        if team and user and team.captain_id != user.id:
+            errors['team'] = 'Only team captain can create or update submissions.'
 
         if round_obj:
             now = timezone.now()

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -35,12 +35,18 @@ class TournamentApiTests(APITestCase):
             password='StrongPass123!',
             role='jury',
         )
+        self.member = User.objects.create_user(
+            username='member',
+            email='member@example.com',
+            password='StrongPass123!',
+        )
         self.team = Team.objects.create(
             name='Test Team',
             email='test@example.com',
             captain=self.captain,
         )
         TeamMember.objects.create(team=self.team, user=self.captain)
+        TeamMember.objects.create(team=self.team, user=self.member)
 
         self.tournament_data = {
             'name': 'Dev Tournament',
@@ -276,6 +282,95 @@ class TournamentApiTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get('code'), 'validation_error')
         self.assertIn('team', response.data['details'])
+
+    def test_non_captain_team_member_cannot_create_submission(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+
+        self.client.force_authenticate(user=self.member)
+        url = reverse('submissions')
+        submission_data = {
+            'team': self.team.id,
+            'round': round_obj.id,
+            'github_url': 'https://github.com/test/repo',
+            'demo_video_url': 'https://youtube.com/test',
+            'description': 'Member submission',
+        }
+        response = self.client.post(url, submission_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get('code'), 'validation_error')
+        self.assertIn('team', response.data['details'])
+
+    def test_non_captain_team_member_cannot_update_submission(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+        submission = Submission.objects.create(
+            team=self.team,
+            round=round_obj,
+            github_url='https://github.com/test/repo',
+            demo_video_url='https://youtube.com/test',
+            description='Captain submission',
+            created_by=self.captain,
+        )
+
+        self.client.force_authenticate(user=self.member)
+        url = reverse('submission_detail', kwargs={'pk': submission.id})
+        response = self.client.patch(url, {'description': 'Updated by member'}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get('code'), 'validation_error')
+        self.assertIn('team', response.data['details'])
+
+    def test_captain_can_update_submission(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+        submission = Submission.objects.create(
+            team=self.team,
+            round=round_obj,
+            github_url='https://github.com/test/repo',
+            demo_video_url='https://youtube.com/test',
+            description='Captain submission',
+            created_by=self.captain,
+        )
+
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('submission_detail', kwargs={'pk': submission.id})
+        response = self.client.patch(url, {'description': 'Updated by captain'}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        submission.refresh_from_db()
+        self.assertEqual(submission.description, 'Updated by captain')
 
     def test_registration_limit_reached(self):
         tournament = Tournament.objects.create(

--- a/backend/tournaments/tests.py
+++ b/backend/tournaments/tests.py
@@ -372,6 +372,152 @@ class TournamentApiTests(APITestCase):
         submission.refresh_from_db()
         self.assertEqual(submission.description, 'Updated by captain')
 
+    def test_tournament_submissions_returns_only_captain_team_submissions(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+        own_submission = Submission.objects.create(
+            team=self.team,
+            round=round_obj,
+            github_url='https://github.com/test/my-team',
+            demo_video_url='https://youtube.com/my-team',
+            created_by=self.captain,
+        )
+
+        other_captain = User.objects.create_user(
+            username='captain-other',
+            email='captain-other@example.com',
+            password='StrongPass123!',
+        )
+        other_team = Team.objects.create(
+            name='Other Team',
+            email='other-team@example.com',
+            captain=other_captain,
+        )
+        TeamMember.objects.create(team=other_team, user=other_captain)
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=other_team)
+        Submission.objects.create(
+            team=other_team,
+            round=round_obj,
+            github_url='https://github.com/test/other-team',
+            demo_video_url='https://youtube.com/other-team',
+            created_by=other_captain,
+        )
+
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_submissions', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], own_submission.id)
+
+    def test_tournament_submissions_does_not_include_other_tournament_submissions(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        other_tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            name='Other tournament',
+            description='Other tournament desc',
+            start_date=timezone.now() + timezone.timedelta(days=2),
+            end_date=timezone.now() + timezone.timedelta(days=12),
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        other_round = Round.objects.create(
+            tournament=other_tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+        TournamentTeamRegistration.objects.create(tournament=other_tournament, team=self.team)
+        own_submission = Submission.objects.create(
+            team=self.team,
+            round=round_obj,
+            github_url='https://github.com/test/current-tournament',
+            demo_video_url='https://youtube.com/current-tournament',
+            created_by=self.captain,
+        )
+        Submission.objects.create(
+            team=self.team,
+            round=other_round,
+            github_url='https://github.com/test/other-tournament',
+            demo_video_url='https://youtube.com/other-tournament',
+            created_by=self.captain,
+        )
+
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_submissions', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], own_submission.id)
+
+    def test_tournament_submissions_returns_empty_for_non_captain_member(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        round_obj = Round.objects.create(
+            tournament=tournament,
+            status=Round.STATUS_ACTIVE,
+            start_date=timezone.now() - timezone.timedelta(hours=1),
+            end_date=timezone.now() + timezone.timedelta(hours=1),
+        )
+        TournamentTeamRegistration.objects.create(tournament=tournament, team=self.team)
+        Submission.objects.create(
+            team=self.team,
+            round=round_obj,
+            github_url='https://github.com/test/repo',
+            demo_video_url='https://youtube.com/test',
+            created_by=self.captain,
+        )
+
+        self.client.force_authenticate(user=self.member)
+        url = reverse('tournament_submissions', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_tournament_submissions_requires_authentication(self):
+        tournament = Tournament.objects.create(
+            created_by=self.admin,
+            status=Tournament.STATUS_RUNNING,
+            **self.tournament_data
+        )
+        url = reverse('tournament_submissions', kwargs={'pk': tournament.id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_tournament_submissions_returns_404_for_missing_tournament(self):
+        self.client.force_authenticate(user=self.captain)
+        url = reverse('tournament_submissions', kwargs={'pk': 999999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_registration_limit_reached(self):
         tournament = Tournament.objects.create(
             created_by=self.admin,

--- a/backend/tournaments/views.py
+++ b/backend/tournaments/views.py
@@ -393,14 +393,16 @@ class RoundMarkEvaluatedView(SyncStatusesMixin, APIView):
 
 class TournamentSubmissionsView(SyncStatusesMixin, generics.ListAPIView):
     serializer_class = SubmissionSerializer
-    # permission_classes = [IsAuthenticated, CanViewTournament]  # тільки для журі/адмін
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         tournament = get_object_or_404(Tournament, pk=self.kwargs['pk'])
         return (
             Submission.objects.select_related('team', 'round', 'round__tournament')
-            .filter(round__tournament=tournament)
+            .filter(
+                round__tournament=tournament,
+                team__captain_id=self.request.user.id,
+            )
             .order_by('-updated_at')
         )
 


### PR DESCRIPTION
Submission тепер може створювати/редагувати лише капітан команди.
Ендпоінт `GET /api/tournaments/{id}/submissions/` повертає тільки submissions команд, де поточний користувач є капітаном. Жодних параметрів передавати не потрібно, фільтрація повністю на бекенді.